### PR TITLE
SlackBuild 自动下载源文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# backup files
+*~
+*.bak
+*.swp
+
+# source files
+*.deb
+

--- a/cloud_music.SlackBuild
+++ b/cloud_music.SlackBuild
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Slackware build script for <appname>
+# Slackware build script for cloud_music
 
-# Copyright <year> <you> <where you live>
+# Copyright (c) 2016 nnnewb <weak_ptr@163.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -22,83 +22,107 @@
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-PRGNAM=cloud_music			# replace with name of program
-VERSION=${VERSION:-0.9.0}	# replace with version of program
+PRGNAM='cloud_music'
+VERSION=${VERSION:-0.9.0}
 BUILD=${BUILD:-1}
-TAG=${TAG:-_SBo}		# the "_SBo" is required
+TAG=${TAG:-_SBo}
+CWD=$(dirname $(readlink -f $0))
+TMP=${TMP:-/tmp/SBo}
+PKG="${TMP}/package-${PRGNAM}"
+OUTPUT=${OUTPUT:-/tmp}
+SOURCE_URL=''
+SOURCE=''
+SHA256SUMS=('d118d78c62d3d9745fe290dcb5ba0b7412c32f6aa01ae59f8065fd677a208995')
 
 # Automatically determine the architecture we're building on:
 if [ -z "$ARCH" ]; then
-  case "$( uname -m )" in
+  case "$(uname -m)" in
     i?86) ARCH=i486 ;;
     arm*) ARCH=arm ;;
     # Unless $ARCH is already set, use uname -m for all other archs:
-       *) ARCH=$( uname -m ) ;;
+       *) ARCH=$(uname -m) ;;
   esac
 fi
 
-CWD=$(pwd)
-TMP=${TMP:-/tmp/SBo}	# For consistency's sake, use this
-PKG=$TMP/package-$PRGNAM
-OUTPUT=${OUTPUT:-/tmp}	# Drop the package in /tmp
-
-set -e # Exit on most errors
+set -e
 # If you prefer to do selective error checking with
 #   command || exit 1
 # then that's also acceptable.
 
-rm -rf $PKG
-mkdir -p $TMP $PKG $OUTPUT
-cd $TMP
-rm -rf $PRGNAM-$VERSION
-# tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
-cd $PKG
-if [ $ARCH = "i486" ]; then
-    ar xvf $CWD/netease-cloudd-music_0.9.0-1_i386.deb
-else
-    ar xvf $CWD/netease-cloud-music_0.9.0-1_amd64.deb
-fi
-tar xvf data.tar.xz
-rm -f control.tar.gz
-rm -f data.tar.xz
-rm -f debian-binary
+cd $CWD
 
-# patch for undefiend symbol: g_type_class_adjust_private_offset
-mkdir glib_new_version
-cd glib_new_version
+# Get source
+# {
+case $ARCH in
+  *86)
+    SOURCE_URL='http://s1.music.126.net/download/pc/netease-cloud-music_0.9.0-1_i386.deb'
+    ;;
+  *64)
+    SOURCE_URL='http://s1.music.126.net/download/pc/netease-cloud-music_0.9.0-1_amd64.deb'
+    ;;
+  *)
+    SOURCE_URL=''
+    ;;
+esac
+SOURCE=$(basename $SOURCE_URL)
+test -z $SOURCE_URL && (echo "Unsupport arch ${ARCH}." || exit 1) || wget -nc $SOURCE_URL
+# 此处避免使用下标，因为不同shell 中数组下标规则不同，有使用其他shell 执行SlackBuild 的可能
+[[ $(echo ${SHA256SUMS[@]} | awk '{print $1}') != $(sha256sum $SOURCE | awk '{print $1}') ]] && (echo "Bad file ${SOURCE}" && exit 1)
+# }
+
+test -d $PKG && rm -rvf $PKG
+mkdir -p $TMP $PKG $OUTPUT
+
+cd $TMP
+test -d "${PRGNAM}-${VERSION}" && rm -rvf "${PRGNAM}-${VERSION}"
+# tar -zxvf $CWD/$PRGNAM-$VERSION.tar.gz
+
+cd $PKG
+ar -xvf "${CWD}/${SOURCE}"
+tar -Jxvf data.tar.xz
+rm -f control.tar.gz data.tar.xz debian-binary
+
+# Patch for undefiend symbol: g_type_class_adjust_private_offset
+# See https://github.com/slackwarecn/netease_cloud_music_slackbuild/issues/2
+# {
 if [ $ARCH = "i486" ]; then
-    tar xvf $CWD/glib2-2.46.2-i586-2.txt
-    cp usr/lib/libglib-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
-    cp usr/lib/libgobject-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
+  CUSTOM_GLIBC2='glib2-2.46.2-i586-2.txz'
 else
-    tar xvf $CWD/glib2-2.46.2-x86_64-2.txz
-    mkdir -p ../usr/lib64/
-    cp usr/lib64/libglib-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
-    cp usr/lib64/libgobject-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
+  CUSTOM_GLIBC2='glib2-2.46.2-x86_64-2.txz'
 fi
-cd ..
-rm -rf glib_new_version
-touch usr/lib/netease-cloud-music/cloud_music.sh
-echo "#!/bin/sh" > usr/lib/netease-cloud-music/cloud_music.sh
-echo "LD_PRELOAD=libglib-2.0.so.0.4600.2:libgobject-2.0.so.0.4600.2 /usr/lib/netease-cloud-music/netease-cloud-music"\
-    >> usr/lib/netease-cloud-music/cloud_music.sh
-chmod +x usr/lib/netease-cloud-music/cloud_music.sh
-rm -f usr/bin/netease-cloud-music
+if [[ -r $CUSTOM_GLIBC2 ]]
+then
+  CUSTOM_GLIBC2_DIR='glib_new_version'
+
+  mkdir $CUSTOM_GLIBC2_DIR && cd $CUSTOM_GLIBC2_DIR || exit 1
+  tar -Jxvf "$CWD/${CUSTOM_GLIBC2}"
+  install -Dm0755 usr/lib/libglib-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
+  install -Dm0755 usr/lib/libgobject-2.0.so.0.4600.2 ../usr/lib/netease-cloud-music
+  cd ..
+  rm -rf $CUSTOM_GLIBC2_DIR
+  touch usr/lib/netease-cloud-music/cloud_music.sh
+  echo "#!/bin/sh" > usr/lib/netease-cloud-music/cloud_music.sh
+  echo "LD_PRELOAD=libglib-2.0.so.0.4600.2:libgobject-2.0.so.0.4600.2 /usr/lib/netease-cloud-music/netease-cloud-music"\
+      >> usr/lib/netease-cloud-music/cloud_music.sh
+  chmod +x usr/lib/netease-cloud-music/cloud_music.sh
+  rm -f usr/bin/netease-cloud-music
+fi
+# }
 
 chmod +x usr/lib/netease-cloud-music/libcef.so
-chown -R root:root .
 
-mkdir $PKG/usr/doc/$PRGNAM-$VERSION -p
-cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
+mkdir -p "${PKG}/usr/doc/${PRGNAM}-${VERSION}"
+install -Dm0755 "${CWD}/${PRGNAM}.SlackBuild" "${PKG}/usr/doc/${PRGNAM}-${VERSION}/${PRGNAM}.SlackBuild"
 
 # Copy the slack-desc (and a custom doinst.sh if necessary) into ./install
-mkdir -p $PKG/install
-cat $CWD/slack-desc > $PKG/install/slack-desc
-cat $CWD/doinst.sh > $PKG/install/doinst.sh
+mkdir -p "${PKG}/install"
+install -Dm0755 "${CWD}/slack-desc" "${PKG}/install/slack-desc"
+install -Dm0755 "${CWD}/doinst.sh" "${PKG}/install/doinst.sh"
 
 # Make the package; be sure to leave it in $OUTPUT
 # If package symlinks need to be created during install *before*
 # your custom contents of doinst.sh runs, then add the -p switch to
 # the makepkg command below -- see makepkg(8) for details
 cd $PKG
-/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.${PKGTYPE:-tgz}
+/sbin/makepkg -l y -c n "${OUTPUT}/${PRGNAM}-${VERSION}-${ARCH}-${BUILD}${TAG}.${PKGTYPE:-tgz}"
+


### PR DESCRIPTION
Fix #6 Close #5 Ref #4 Ref #3

此Patch 和#3 冲突，Merge 前请留意。
- 在SlackBuild 中自动下载和校验源文件
- 修改了使用不当的指令
- 规范了除#2 Patch 部分的编码
- 添加了.gitignore 文件
- 添加了版权信息
