### PR TITLE
Bug 修复

### DIFF
--- a/cloud_music.SlackBuild
+++ b/cloud_music.SlackBuild
@@ -54,11 +54,7 @@ rm -f control.tar.gz data.tar.xz debian-binary
 
 # Patch for undefiend symbol: g_type_class_adjust_private_offset
 # See https://github.com/slackwarecn/netease_cloud_music_slackbuild/issues/2 {
-if [ $ARCH = "i486" ]; then
-  CUSTOM_GLIB2='glib2-2.46.2-i586-2.txz'
-else
-  CUSTOM_GLIB2='glib2-2.46.2-x86_64-2.txz'
-fi
+CUSTOM_GLIB2=$(basename $GLIB2_URL)
 
 if [ -r "${CWD}/${CUSTOM_GLIB2}" ]; then
   CUSTOM_GLIB2_DIR='glib_new_version'

--- a/conf.sh
+++ b/conf.sh
@@ -3,10 +3,15 @@
 # Automatically determine the architecture we're building on:
 if [ -z "$ARCH" ]; then
   case "$(uname -m)" in
-    i?86) ARCH=i486 ;;
-    arm*) ARCH=arm ;;
-    # Unless $ARCH is already set, use uname -m for all other archs:
-       *) ARCH=$(uname -m) ;;
+    i?86)
+      ARCH=i486
+      break ;;
+    arm*)
+      ARCH=arm
+      break ;;
+    *)
+      ARCH=$(uname -m)
+      break ;;
   esac
 fi
 

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -12,16 +12,16 @@ SHA256SUMS=(
 
 source "${CWD}/conf.sh"
 
-echo -ne "Prebuild...\t"
+echo -ne "Prebuilding...\t"
 
 SOURCE=$(basename $SOURCE_URL)
 test -n $SOURCE_URL
-wget -nc $SOURCE_URL 2>/dev/null
+wget -N $SOURCE_URL 2>/dev/null
 test $(echo ${SHA256SUMS[@]} | awk '{print $1}') == $(sha256sum $SOURCE | awk '{print $1}')
 
 GLIB2=$(basename $GLIB2_URL)
 test -n $GLIB2_URL
-wget -nc $GLIB2_URL 2>/dev/null
+wget -N $GLIB2_URL 2>/dev/null
 if echo $GLIB2_URL | grep -o 'x86_64' >/dev/null 2>&1; then
   test $(echo ${SHA256SUMS[@]} | awk '{print $3}') == $(sha256sum $GLIB2 | awk '{print $1}')
 else


### PR DESCRIPTION
- 修复了官方模板中设置ARCH 变量时的逻辑错误
- CUSTOM_GLIB2 不再使用硬编码，其值取决于conf.sh
- wget 遇到下坏的同名文件，现在会再次试图下载
